### PR TITLE
extend privleges of roadmin user for mysqldump (still read-only)

### DIFF
--- a/mariadb_helper/mariadb_helper.go
+++ b/mariadb_helper/mariadb_helper.go
@@ -262,7 +262,7 @@ func (m MariaDBHelper) ManageReadOnlyUser() error {
 
 func (m MariaDBHelper) grantUserReadOnly(db *sql.DB) error {
 	createUserQuery := fmt.Sprintf(
-		"GRANT SELECT, PROCESS ON *.* TO '%s' IDENTIFIED BY '%s'",
+		"GRANT SELECT, PROCESS, SHOW VIEW, TRIGGER, LOCK TABLES, RELOAD, FILE ON *.* TO '%s' IDENTIFIED BY '%s'",
 		m.config.ReadOnlyUser,
 		m.config.ReadOnlyPassword,
 	)


### PR DESCRIPTION
Hi

We wish to use roadmin user with shield backup plugin mysql (mysqldump)

testing:

```
MariaDB [(none)]> GRANT SELECT, PROCESS, SHOW VIEW, TRIGGER, LOCK TABLES, RELOAD, FILE ON *.* TO 'roadmin'@'%';
Query OK, 0 rows affected (0.01 sec)

MariaDB [(none)]> show grants for roadmin;
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Grants for roadmin@%                                                                                                                                            |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
| GRANT SELECT, RELOAD, PROCESS, FILE, LOCK TABLES, SHOW VIEW, TRIGGER ON *.* TO 'roadmin'@'%' IDENTIFIED BY PASSWORD '*$PASSWORD' |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

MariaDB [(none)]> select VERSION();
+-----------------+
| VERSION()       |
+-----------------+
| 10.1.20-MariaDB |
+-----------------+
1 row in set (0.00 sec)
```
